### PR TITLE
Hide some low-level metadata fields that are fixed properties.

### DIFF
--- a/nci_seer/web_client/views/ItemView.js
+++ b/nci_seer/web_client/views/ItemView.js
@@ -64,6 +64,12 @@ wrap(ItemView, 'render', function (render) {
         if (isAperio && keyname.match(/^internal;openslide;(openslide.comment|tiff.ImageDescription)$/)) {
             return true;
         }
+        if (keyname.match(/^internal;openslide;openslide.level\[/)) {
+            return true;
+        }
+        if (keyname.match(/^internal;openslide;hamamatsu.(AHEX|MHLN)\[/)) {
+            return true;
+        }
         return false;
     };
 


### PR DESCRIPTION
This would never be redacted and clutter the interface.