### PR TITLE
Track more information on redaction and export.

### DIFF
--- a/nci_seer/__init__.py
+++ b/nci_seer/__init__.py
@@ -11,7 +11,7 @@ try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     # package is not installed
-    pass
+    __version__ = 'development'
 
 
 @setting_utilities.validator({

--- a/nci_seer/import_export.py
+++ b/nci_seer/import_export.py
@@ -183,6 +183,8 @@ def exportItems(ctx, user=None, all=False):
     :param all: True to export all items.  False to only export items that have
         not been previously exported.
     """
+    from . import __version__
+
     exportPath = Setting().get(PluginSettings.NCISEER_EXPORT_PATH)
     exportFolderId = Setting().get(PluginSettings.HUI_FINISHED_FOLDER)
     if not exportPath or not exportFolderId:
@@ -214,6 +216,7 @@ def exportItems(ctx, user=None, all=False):
             exportedRecord.append({
                 'time': datetime.datetime.utcnow().isoformat(),
                 'user': str(user['_id']) if user else None,
+                'version': __version__,
             })
             item = Item().setMetadata(item, {'nciseerExported': exportedRecord})
             report.append({'item': item, 'status': 'export'})

--- a/nci_seer/rest.py
+++ b/nci_seer/rest.py
@@ -124,6 +124,8 @@ def process_item(item, user=None):
     :param user: the user performing the processing.
     :returns: the item after move.
     """
+    from . import __version__
+
     origFolderId = Setting().get(PluginSettings.HUI_ORIGINAL_FOLDER)
     procFolderId = Setting().get(PluginSettings.HUI_PROCESSED_FOLDER)
     if not origFolderId or not procFolderId:
@@ -166,8 +168,13 @@ def process_item(item, user=None):
     item['meta']['redacted'].append({
         'user': str(user['_id']) if user else None,
         'time': datetime.datetime.utcnow().isoformat(),
+        'redactList': item['meta'].get('redactList'),
+        'version': __version__,
     })
     item['meta'].pop('quarantine', None)
+    if 'nciseerExported' in item['meta']:
+        item['meta']['redacted'][-1]['previousExports'] = item['meta']['nciseerExported']
+    item['meta'].pop('nciseerExported', None)
     item['updated'] = datetime.datetime.utcnow()
     item = move_item(item, user, PluginSettings.HUI_PROCESSED_FOLDER)
     return item

--- a/nci_seer/web_client/views/HierarchyWidget.js
+++ b/nci_seer/web_client/views/HierarchyWidget.js
@@ -34,7 +34,7 @@ function performAction(action) {
         if (resp.action === 'export' || resp.action === 'exportall') {
             [
                 ['export', 'exported'],
-                ['different', 'are different from those already present'],
+                ['different', 'already present but different'],
                 ['present', 'already exported']
             ].forEach(([key, desc]) => {
                 if (resp[key]) {


### PR DESCRIPTION
Add the version and redaction list to the redaction record.

Add the version to the export record.

When redacting, ensure the export record is cleared.