### PR TITLE
Change top branding from Digital Slide Archive to SEER DSA.

### DIFF
--- a/devops/nciseer/provision.py
+++ b/devops/nciseer/provision.py
@@ -24,13 +24,13 @@ if User().findOne() is None:
 adminUser = User().findOne({'admin': True})
 
 # Set branding
-Setting().set('core.brand_name', 'Digital Slide Archive')
+Setting().set('core.brand_name', 'SEER DSA')
 Setting().set('homepage.markdown', """
-# Digital Slide Archive
+# SEER Digital Slide Archive
 ---
 ## NCI SEER Pediatic WSI Pilot
 
-Welcome to the **Digital Slide Archive**.
+Welcome to the **SEER Digital Slide Archive**.
 
 Developers who want to use the Girder REST API should check out the
 [interactive web API docs](api/v1).


### PR DESCRIPTION
The home page now reads "SEER Digital Slide Archive" where it had before read "Digital Slide Archive".

This closes #69.