### PR TITLE
Skip files that fail to import.

### DIFF
--- a/USAGE.rst
+++ b/USAGE.rst
@@ -121,6 +121,7 @@ After the image names and information in the metadata file are reconciled, the D
 - ``replaced``: The image is listed in an excel file, is in the DSA, but has a different file size from the image in the DSA. The existing file is removed from the DSA and re-added.
 - ``missing``: The image is listed in an excel file but is not in the import directory. No action is performed.
 - ``unlisted``: The image is not listed in an excel file but is in the import directory. No action is performed.
+- ``failed``: The listed file cannot be read as an image file.
 
 After all images and excel metadata files have been processed, a message is displayed summarizing what images were in each of the five states above (e.g., "Import complete. 19 files added. 1 file missing from import folder"), and then UI is then refreshed.
 

--- a/nci_seer/web_client/views/HierarchyWidget.js
+++ b/nci_seer/web_client/views/HierarchyWidget.js
@@ -24,7 +24,8 @@ function performAction(action) {
                 ['replaced', 'replaced'],
                 ['missing', 'missing from import folder'],
                 ['unlisted', 'missing from manifests'],
-                ['present', 'already present']
+                ['present', 'already present'],
+                ['failed', 'failed to import']
             ].forEach(([key, desc]) => {
                 if (resp[key]) {
                     text += `  ${resp[key]} image${resp[key] > 1 ? 's' : ''} ${desc}.`;


### PR DESCRIPTION
Before the import process stopped with the first bad file left in the system.  Now, such files do not end up in the system and the number of failed files is reported.